### PR TITLE
Support for non-colorized string output in libxdisasm

### DIFF
--- a/include/xdisasm.h
+++ b/include/xdisasm.h
@@ -31,6 +31,8 @@
 #define ARCH_sparc 7
 #define ARCH_sh4 8
 
+extern int xdisasm_no_color_g;
+
 // instruction structure
 typedef struct insn_t{
     unsigned long long vma;

--- a/include/xdisasm.h
+++ b/include/xdisasm.h
@@ -31,6 +31,9 @@
 #define ARCH_sparc 7
 #define ARCH_sh4 8
 
+//Set this before calling disassemble() or disassemble_one()
+//to disble colorized strings. Ideal for redirecting output to 
+//a file or to less/grep/etc.
 extern int xdisasm_no_color_g;
 
 // instruction structure

--- a/src/xdisasm.c
+++ b/src/xdisasm.c
@@ -38,6 +38,8 @@ char * currptr = curr_insn_str;
 disassembler_ftype disas = NULL; // disassembler 
 disassemble_info* dis = NULL;   // disassembly information structure
 char * disas_options = NULL;
+int xdisasm_no_color_g=0;
+
 
 // insn_t -> void
 // Free the memory
@@ -331,7 +333,10 @@ insn_t * disassemble_one(unsigned long long vma, char * rawbuf, size_t buflen, i
     dis->buffer_vma = vma;
     dis->buffer = buf;
     dis->buffer_length = buflen;
-    dis->print_address_func = override_print_address;
+    if(!xdisasm_no_color_g)
+    {
+        dis->print_address_func = override_print_address;
+    }
     dis->disassembler_options = disas_options;
 
     pos = vma;
@@ -406,7 +411,10 @@ insn_list * disassemble(unsigned long long vma, char * rawbuf, size_t buflen, in
     dis->buffer_vma = vma;
     dis->buffer = buf;
     dis->buffer_length = buflen;
-    dis->print_address_func = override_print_address;
+    if(!xdisasm_no_color_g)
+    {
+        dis->print_address_func = override_print_address;
+    }
     dis->disassembler_options = disas_options;
 
     length = dis->buffer_length;


### PR DESCRIPTION
I wanted to add non-colorized output in xrop, so I needed to add it here since some values in the disassembly get colorized.